### PR TITLE
Add mutation utilities and adaptive fuzzing retries

### DIFF
--- a/bounty_hunter/mutate.py
+++ b/bounty_hunter/mutate.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+import random, urllib.parse, base64
+
+SPECIAL_CHARS=['"',"'",";","|","&"]
+
+def random_case(s: str) -> str:
+    return ''.join(c.upper() if random.random()>0.5 else c.lower() for c in s)
+
+def percent_encode_random(s: str) -> str:
+    out=[]
+    for ch in s:
+        if ch.isalnum() or random.random()>0.5:
+            out.append(ch)
+        else:
+            out.append("%{:02x}".format(ord(ch)))
+    return ''.join(out)
+
+def insert_special(s: str) -> str:
+    ch=random.choice(SPECIAL_CHARS)
+    pos=random.randint(0, len(s))
+    return s[:pos]+ch+s[pos:]
+
+def encode_alt(s: str) -> list[str]:
+    q=urllib.parse.quote(s, safe='')
+    return [q, urllib.parse.quote(q, safe=''), base64.b64encode(s.encode()).decode()]
+
+def generate_variants(probe: str) -> list[str]:
+    variants={probe, random_case(probe), percent_encode_random(probe), insert_special(probe)}
+    variants.update(encode_alt(probe))
+    return list(variants)
+
+def alternate_encodings(probe: str) -> list[str]:
+    return encode_alt(probe)


### PR DESCRIPTION
## Summary
- add mutate module to randomize case, encoding, and special characters for probes
- update fuzz coordinator to generate variants and retry with alternate encodings on 403/406
- return HTTP status from requests to guide adaptive fuzzing

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_68a665618f008329a4461f71b90cd92c