### PR TITLE
feat: add confirmation checks and confidence gating

### DIFF
--- a/bounty_hunter/config.py
+++ b/bounty_hunter/config.py
@@ -27,4 +27,7 @@ class Settings(BaseSettings):
     # Fingerprinter DB (optional local file)
     CVE_FAVICON_DB: str | None = Field(default=None)
 
+    # Findings
+    CONFIDENCE_THRESHOLD: float = Field(default=0.5, env="BH_CONFIDENCE_THRESHOLD")
+
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}

--- a/bounty_hunter/report.py
+++ b/bounty_hunter/report.py
@@ -31,9 +31,10 @@ class ReportWriter:
         md=f"""
 # {f.category}
 
-**Program:** {self.program}  
-**Endpoint:** `{f.url}`  
+**Program:** {self.program}
+**Endpoint:** `{f.url}`
 **Method:** `{f.method}`
+**Confidence:** {getattr(f,'confidence',0):.2f}
 
 ## Proof of Concept
 ```bash

--- a/bounty_hunter/signatures.py
+++ b/bounty_hunter/signatures.py
@@ -1,4 +1,23 @@
 import re
-XSS_REFLECTION=re.compile(r"BHXSS",re.I)
-SQLI_ERRORS=[re.compile(r"SQL syntax",re.I),re.compile(r"mysql_fetch|PDO|mysqli|ORA-\d+|PostgreSQL|SQLite",re.I)]
-SSTI_REFLECTION=re.compile(r"BHSTI",re.I)
+
+# Multiple regex patterns for each category of indicator. These lists can be
+# extended over time as new signatures are discovered.
+XSS_PATTERNS=[
+    re.compile(r"BHXSS",re.I),
+    re.compile(r"<script[^>]*>BHXSS</script>",re.I),
+]
+
+SQLI_ERRORS=[
+    re.compile(r"SQL syntax",re.I),
+    re.compile(r"mysql_fetch|PDO|mysqli|ORA-\d+|PostgreSQL|SQLite",re.I),
+    re.compile(r"SQLSTATE\[HY000\]",re.I),
+]
+
+SSTI_PATTERNS=[
+    re.compile(r"BHSTI",re.I),
+    re.compile(r"7\s*\*\s*7",re.I),
+]
+
+# Responses taking longer than this threshold (in seconds) will be flagged as
+# potential time based vulnerabilities.
+RESPONSE_TIME_THRESHOLD=5


### PR DESCRIPTION
## Summary
- extend vulnerability signatures with multiple regexes and timing threshold
- confirm indicators with follow-up requests and confidence scoring
- gate reports by configurable confidence and log levels

## Testing
- `python -m py_compile bounty_hunter/signatures.py bounty_hunter/fuzz.py bounty_hunter/config.py bounty_hunter/report.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a66563d0648329874e0d3a2cffd05d