### PR TITLE
feat: add host allowlist and safer fuzzing requests

### DIFF
--- a/bounty_hunter/config.py
+++ b/bounty_hunter/config.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from pydantic_settings import BaseSettings
-from pydantic import Field
+from pydantic import Field, field_validator
 
 class Settings(BaseSettings):
     # Networking
@@ -8,6 +8,10 @@ class Settings(BaseSettings):
     RETRIES: int = Field(default=2, env="BH_RETRY")
     MAX_CONCURRENCY: int = Field(default=40, env="BH_MAX_CONCURRENCY")
     PER_HOST: int = Field(default=5, env="BH_PER_HOST")
+    MAX_RESPONSE_SIZE: int = Field(default=1024 * 1024, env="BH_MAX_RESPONSE_SIZE")
+    MAX_REDIRECT_DEPTH: int = Field(default=3, env="BH_MAX_REDIRECT_DEPTH")
+    JITTER_S: float = Field(default=0.0, env="BH_JITTER_S")
+    ALLOWED_HOSTS: list[str] = Field(default_factory=list, env="BH_ALLOWED_HOSTS")
 
     # LLM
     LLM_PROVIDER: str = "none"  # none|openai
@@ -26,5 +30,12 @@ class Settings(BaseSettings):
 
     # Fingerprinter DB (optional local file)
     CVE_FAVICON_DB: str | None = Field(default=None)
+
+    @field_validator("ALLOWED_HOSTS", mode="before")
+    @classmethod
+    def split_hosts(cls, v: str | list[str]) -> list[str]:
+        if isinstance(v, str):
+            return [h.strip() for h in v.split(",") if h.strip()]
+        return v
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}


### PR DESCRIPTION
## Summary
- add ALLOWED_HOSTS and request safety settings
- filter endpoints against ALLOWED_HOSTS before scanning
- add jitter and response/redirect limits for fuzzing requests

## Testing
- `python -m py_compile bounty_hunter/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68a665671880832980b79d2e9244d98a