### PR TITLE
feat: add scan resume and module toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,9 @@ python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 python -m bounty_hunter scan --targets scope.txt --program "Acme BBP" --template h1
 ```
+
+## Resuming & Configuration
+
+- Resume a previous scan by pointing `--outdir` to an existing run and adding `--resume`.
+- Module behaviour can be controlled via the `.env` file.  Set `BH_FUZZ_ENABLED=false`,
+  `BH_JS_MINER_ENABLED=false`, etc. to disable specific modules.

--- a/bounty_hunter/cli.py
+++ b/bounty_hunter/cli.py
@@ -19,6 +19,7 @@ def scan(
     per_host: int = typer.Option(None),
     template: str = typer.Option("index"),
     oob: bool = typer.Option(False),
+    resume: bool = typer.Option(False, help="Resume from previous state"),
 ):
     s = Settings()
     if max_concurrency: s.MAX_CONCURRENCY = max_concurrency
@@ -27,4 +28,4 @@ def scan(
     console.rule("[bold cyan]AI Bug Bounty Hunter")
     console.print(f"Program: [bold]{program}[/] | LLM: [bold]{s.LLM_PROVIDER}[/] | OOB: [bold]{s.OOB_ENABLED}[/]")
     console.print(f"Concurrency: {s.MAX_CONCURRENCY} (per-host {s.PER_HOST})\n")
-    asyncio.run(run_scan(targets, outdir, program, s, template=template))
+    asyncio.run(run_scan(targets, outdir, program, s, template=template, resume=resume))

--- a/bounty_hunter/config.py
+++ b/bounty_hunter/config.py
@@ -24,6 +24,15 @@ class Settings(BaseSettings):
     INTERACTSH_TOKEN: str | None = Field(default=None)
     INTERACTSH_POLL_SECONDS: int = Field(default=8)
 
+    # Module toggles
+    JS_MINER_ENABLED: bool = Field(default=True, env="BH_JS_MINER_ENABLED")
+    FUZZ_ENABLED: bool = Field(default=True, env="BH_FUZZ_ENABLED")
+    REDIRECTS_ENABLED: bool = Field(default=True, env="BH_REDIRECTS_ENABLED")
+    AUTHCHECK_ENABLED: bool = Field(default=True, env="BH_AUTHCHECK_ENABLED")
+    SIGNEDURL_ENABLED: bool = Field(default=True, env="BH_SIGNEDURL_ENABLED")
+    JWTCHECK_ENABLED: bool = Field(default=True, env="BH_JWTCHECK_ENABLED")
+    FINGERPRINTER_ENABLED: bool = Field(default=True, env="BH_FINGERPRINTER_ENABLED")
+
     # Fingerprinter DB (optional local file)
     CVE_FAVICON_DB: str | None = Field(default=None)
 

--- a/bounty_hunter/engine.py
+++ b/bounty_hunter/engine.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-import anyio, httpx
+import json, anyio, httpx
 from pathlib import Path
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn
@@ -18,43 +18,114 @@ from .fingerprinter import Fingerprinter
 
 console = Console()
 
-async def run_scan(targets_path: Path, outdir: Path, program: str, settings: Settings, template: str = "index"):
+async def run_scan(targets_path: Path, outdir: Path, program: str, settings: Settings, template: str = "index", resume: bool = False):
     targets = [t.strip() for t in targets_path.read_text().splitlines() if t.strip() and not t.strip().startswith('#')]
     if not targets:
         console.print("[bold red]No targets provided."); return
-    outdir = outdir / f"{int(anyio.current_time())}"; outdir.mkdir(parents=True, exist_ok=True)
+
+    if resume:
+        state_path = outdir / "state.json"
+        if not state_path.exists():
+            console.print("[bold yellow]No cached state found; starting a new scan[/]")
+            resume = False
+    if not resume:
+        outdir = outdir / f"{int(anyio.current_time())}"
+        outdir.mkdir(parents=True, exist_ok=True)
+        state_path = outdir / "state.json"
+    else:
+        outdir.mkdir(parents=True, exist_ok=True)
+
+    progress = {
+        "harvest": False,
+        "jsminer": False,
+        "fuzz": False,
+        "redirect": False,
+        "auth": False,
+        "signedurl": False,
+        "jwt": False,
+        "fingerprint": False,
+        "oob": False,
+    }
+    endpoints: list[str] = []
+    if resume:
+        data = json.loads(state_path.read_text())
+        endpoints = data.get("endpoints", [])
+        progress.update(data.get("progress", {}))
+
+    def save_state() -> None:
+        state = {"endpoints": endpoints, "progress": progress}
+        state_path.write_text(json.dumps(state, indent=2))
+
     limits = httpx.Limits(max_connections=settings.MAX_CONCURRENCY, max_keepalive_connections=settings.MAX_CONCURRENCY)
     timeout = httpx.Timeout(settings.TIMEOUT_S)
     transport = httpx.HTTPTransport(retries=settings.RETRIES)
     async with httpx.AsyncClient(http2=True, limits=limits, timeout=timeout, transport=transport, follow_redirects=False) as client:
         llm = LLM.from_settings(settings)
-        with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}")) as p:
-            p.add_task(description="Harvesting endpoints…", total=None)
-            endpoints = await harvest_from_targets(client, targets, settings)
-        endpoints = sorted(set(endpoints))
-        console.print(f"[green]\u2714[/] Harvested [bold]{len(endpoints)}[/] candidate endpoints")
+        if not progress["harvest"]:
+            with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}")) as p:
+                p.add_task(description="Harvesting endpoints…", total=None)
+                endpoints = await harvest_from_targets(client, targets, settings)
+            endpoints = sorted(set(endpoints))
+            progress["harvest"] = True
+            save_state()
+            console.print(f"[green]\u2714[/] Harvested [bold]{len(endpoints)}[/] candidate endpoints")
+        else:
+            console.print(f"[green]\u2714[/] Loaded [bold]{len(endpoints)}[/] cached endpoints")
+
         reporter = ReportWriter(base=outdir, program=program, template=template)
-        # JS miner expands scope
-        mined = await JSMiner(client, settings).mine(endpoints)
-        if mined:
-            console.print(f"[cyan]＋[/] JS miner discovered [bold]{len(mined)}[/] extra candidates"); endpoints.extend(mined)
-        # Core fuzz
-        await FuzzCoordinator(client=client, llm=llm, reporter=reporter, settings=settings).run(endpoints)
-        # Targeted checks
-        await RedirectChecker(client, reporter, settings).run(endpoints)
-        await AuthChecker(client, reporter, settings).run(endpoints)
-        await SignedURLChecker(client, reporter, settings).run(endpoints)
-        await JWTChecker(client, reporter, settings).run(endpoints)
-        # Fingerprints
-        for fp in await Fingerprinter(client, settings).run(endpoints):
-            await reporter.generic_finding(
-                category=f"Fingerprint: {fp.product}",
-                endpoint=fp.endpoint,
-                evidence=f"mmh3={fp.hash} headers={dict(list(fp.headers.items())[:10])}\\n{fp.notes}",
-                curl=f"curl -i '{fp.endpoint}'",
-            )
-        # OOB SSRF
-        if settings.OOB_ENABLED:
+
+        if not progress["jsminer"] and settings.JS_MINER_ENABLED:
+            mined = await JSMiner(client, settings).mine(endpoints)
+            if mined:
+                console.print(f"[cyan]＋[/] JS miner discovered [bold]{len(mined)}[/] extra candidates")
+                endpoints.extend(mined)
+                endpoints = sorted(set(endpoints))
+            progress["jsminer"] = True
+            save_state()
+        else:
+            progress["jsminer"] = True
+
+        if not progress["fuzz"] and settings.FUZZ_ENABLED:
+            await FuzzCoordinator(client=client, llm=llm, reporter=reporter, settings=settings).run(endpoints)
+        progress["fuzz"] = True
+        save_state()
+
+        if not progress["redirect"] and settings.REDIRECTS_ENABLED:
+            await RedirectChecker(client, reporter, settings).run(endpoints)
+        progress["redirect"] = True
+        save_state()
+
+        if not progress["auth"] and settings.AUTHCHECK_ENABLED:
+            await AuthChecker(client, reporter, settings).run(endpoints)
+        progress["auth"] = True
+        save_state()
+
+        if not progress["signedurl"] and settings.SIGNEDURL_ENABLED:
+            await SignedURLChecker(client, reporter, settings).run(endpoints)
+        progress["signedurl"] = True
+        save_state()
+
+        if not progress["jwt"] and settings.JWTCHECK_ENABLED:
+            await JWTChecker(client, reporter, settings).run(endpoints)
+        progress["jwt"] = True
+        save_state()
+
+        if not progress["fingerprint"] and settings.FINGERPRINTER_ENABLED:
+            for fp in await Fingerprinter(client, settings).run(endpoints):
+                await reporter.generic_finding(
+                    category=f"Fingerprint: {fp.product}",
+                    endpoint=fp.endpoint,
+                    evidence=f"mmh3={fp.hash} headers={dict(list(fp.headers.items())[:10])}\n{fp.notes}",
+                    curl=f"curl -i '{fp.endpoint}'",
+                )
+        progress["fingerprint"] = True
+        save_state()
+
+        if settings.OOB_ENABLED and not progress["oob"]:
             await OOBSSRF(client, reporter, settings).run(endpoints)
-        (outdir/"INDEX.md").write_text(reporter.finish_index())
+        progress["oob"] = True
+        save_state()
+
+        (outdir / "INDEX.md").write_text(reporter.finish_index())
         console.rule("[bold green]Done"); console.print(f"Reports: [bold]{outdir}[/]")
+


### PR DESCRIPTION
## Summary
- save scan progress and endpoints to `state.json`
- allow resuming scans via new `--resume` flag
- add per-module enable flags in `.env` configuration

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6656d36288329862b50f625b435d8