### PR TITLE
Add Redis task queue for distributed scanning

### DIFF
--- a/bounty_hunter/config.py
+++ b/bounty_hunter/config.py
@@ -27,4 +27,10 @@ class Settings(BaseSettings):
     # Fingerprinter DB (optional local file)
     CVE_FAVICON_DB: str | None = Field(default=None)
 
+    # Task queue
+    REDIS_URL: str = Field(default="redis://localhost:6379/0", env="BH_REDIS_URL")
+    REDIS_QUEUE: str = Field(default="bh:tasks", env="BH_REDIS_QUEUE")
+    CHUNK_SIZE: int = Field(default=50, env="BH_CHUNK_SIZE")
+    WORKERS: int = Field(default=4, env="BH_WORKERS")
+
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}

--- a/bounty_hunter/engine.py
+++ b/bounty_hunter/engine.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-import anyio, httpx
+import anyio, httpx, json
+import redis.asyncio as redis
 from pathlib import Path
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn
@@ -27,6 +28,7 @@ async def run_scan(targets_path: Path, outdir: Path, program: str, settings: Set
     timeout = httpx.Timeout(settings.TIMEOUT_S)
     transport = httpx.HTTPTransport(retries=settings.RETRIES)
     async with httpx.AsyncClient(http2=True, limits=limits, timeout=timeout, transport=transport, follow_redirects=False) as client:
+        rc = redis.from_url(settings.REDIS_URL, decode_responses=True)
         llm = LLM.from_settings(settings)
         with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}")) as p:
             p.add_task(description="Harvesting endpoints…", total=None)
@@ -34,27 +36,40 @@ async def run_scan(targets_path: Path, outdir: Path, program: str, settings: Set
         endpoints = sorted(set(endpoints))
         console.print(f"[green]\u2714[/] Harvested [bold]{len(endpoints)}[/] candidate endpoints")
         reporter = ReportWriter(base=outdir, program=program, template=template)
-        # JS miner expands scope
         mined = await JSMiner(client, settings).mine(endpoints)
         if mined:
             console.print(f"[cyan]＋[/] JS miner discovered [bold]{len(mined)}[/] extra candidates"); endpoints.extend(mined)
-        # Core fuzz
-        await FuzzCoordinator(client=client, llm=llm, reporter=reporter, settings=settings).run(endpoints)
-        # Targeted checks
-        await RedirectChecker(client, reporter, settings).run(endpoints)
-        await AuthChecker(client, reporter, settings).run(endpoints)
-        await SignedURLChecker(client, reporter, settings).run(endpoints)
-        await JWTChecker(client, reporter, settings).run(endpoints)
-        # Fingerprints
-        for fp in await Fingerprinter(client, settings).run(endpoints):
-            await reporter.generic_finding(
-                category=f"Fingerprint: {fp.product}",
-                endpoint=fp.endpoint,
-                evidence=f"mmh3={fp.hash} headers={dict(list(fp.headers.items())[:10])}\\n{fp.notes}",
-                curl=f"curl -i '{fp.endpoint}'",
-            )
-        # OOB SSRF
-        if settings.OOB_ENABLED:
-            await OOBSSRF(client, reporter, settings).run(endpoints)
+        endpoints = sorted(set(endpoints))
+        await rc.delete(settings.REDIS_QUEUE)
+        for i in range(0, len(endpoints), settings.CHUNK_SIZE):
+            chunk = endpoints[i:i + settings.CHUNK_SIZE]
+            await rc.rpush(settings.REDIS_QUEUE, json.dumps(chunk))
+
+        async def worker():
+            while True:
+                item = await rc.blpop(settings.REDIS_QUEUE, timeout=1)
+                if not item:
+                    break
+                _, payload = item
+                chunk = json.loads(payload)
+                await FuzzCoordinator(client=client, llm=llm, reporter=reporter, settings=settings).run(chunk)
+                await RedirectChecker(client, reporter, settings).run(chunk)
+                await AuthChecker(client, reporter, settings).run(chunk)
+                await SignedURLChecker(client, reporter, settings).run(chunk)
+                await JWTChecker(client, reporter, settings).run(chunk)
+                for fp in await Fingerprinter(client, settings).run(chunk):
+                    await reporter.generic_finding(
+                        category=f"Fingerprint: {fp.product}",
+                        endpoint=fp.endpoint,
+                        evidence=f"mmh3={fp.hash} headers={dict(list(fp.headers.items())[:10])}\\n{fp.notes}",
+                        curl=f"curl -i '{fp.endpoint}'",
+                    )
+                if settings.OOB_ENABLED:
+                    await OOBSSRF(client, reporter, settings).run(chunk)
+
+        async with anyio.create_task_group() as tg:
+            for _ in range(settings.WORKERS):
+                tg.start_soon(worker)
+        await rc.aclose()
         (outdir/"INDEX.md").write_text(reporter.finish_index())
         console.rule("[bold green]Done"); console.print(f"Reports: [bold]{outdir}[/]")

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ sourcemap==0.2.1   # latest available version (fixes install error)
 mmh3==4.1.0
 PyJWT==2.9.0
 cryptography==43.0.1
+redis>=5.0.0


### PR DESCRIPTION
## Summary
- introduce Redis-backed task queue and worker dispatch in `engine.py`
- add configurable queue settings for chunk size and worker count
- include Redis dependency

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6656ecce883299c825eefd4a93f13