### PR TITLE
feat: mutate probes and retry on block

### DIFF
--- a/bounty_hunter/mutate.py
+++ b/bounty_hunter/mutate.py
@@ -1,33 +1,86 @@
+"""Payload mutation helpers.
+
+This module centralises routines used to fuzz payloads sent during
+vulnerability discovery.  Variants help bypass naive filters by tweaking
+case, encoding and by inserting special characters.
+"""
+
 from __future__ import annotations
-import random, urllib.parse, base64
 
-SPECIAL_CHARS=['"',"'",";","|","&"]
+import base64
+import random
+import urllib.parse
+from typing import List
 
-def random_case(s: str) -> str:
-    return ''.join(c.upper() if random.random()>0.5 else c.lower() for c in s)
+# Characters occasionally useful to sneak past unsanitised concatenation.
+SPECIAL_CHARS = ['"', "'", ';', '|', '&']
 
-def percent_encode_random(s: str) -> str:
-    out=[]
-    for ch in s:
-        if ch.isalnum() or random.random()>0.5:
+
+def random_case(text: str) -> str:
+    """Return ``text`` with randomised character casing."""
+
+    return "".join(
+        ch.upper() if random.random() > 0.5 else ch.lower() for ch in text
+    )
+
+
+def percent_encode_random(text: str) -> str:
+    """Percent–encode a random selection of characters from ``text``."""
+
+    out: List[str] = []
+    for ch in text:
+        if ch.isalnum() or random.random() > 0.5:
             out.append(ch)
         else:
-            out.append("%{:02x}".format(ord(ch)))
-    return ''.join(out)
+            out.append(f"%{ord(ch):02x}")
+    return "".join(out)
 
-def insert_special(s: str) -> str:
-    ch=random.choice(SPECIAL_CHARS)
-    pos=random.randint(0, len(s))
-    return s[:pos]+ch+s[pos:]
 
-def encode_alt(s: str) -> list[str]:
-    q=urllib.parse.quote(s, safe='')
-    return [q, urllib.parse.quote(q, safe=''), base64.b64encode(s.encode()).decode()]
+def insert_special(text: str) -> str:
+    """Insert a random special character at a random position in ``text``."""
+
+    char = random.choice(SPECIAL_CHARS)
+    pos = random.randint(0, len(text))
+    return text[:pos] + char + text[pos:]
+
+
+def _encode_alt(text: str) -> list[str]:
+    """Generate alternative encodings for ``text``."""
+
+    quoted = urllib.parse.quote(text, safe="")
+    double_quoted = urllib.parse.quote(quoted, safe="")
+    b64 = base64.b64encode(text.encode()).decode()
+    return [quoted, double_quoted, b64]
+
 
 def generate_variants(probe: str) -> list[str]:
-    variants={probe, random_case(probe), percent_encode_random(probe), insert_special(probe)}
-    variants.update(encode_alt(probe))
+    """Return a collection of mutated forms of ``probe``.
+
+    Variants include random casing, percent-encoding of random characters,
+    insertion of special characters and a set of alternate encodings.
+    """
+
+    variants = {
+        probe,
+        random_case(probe),
+        percent_encode_random(probe),
+        insert_special(probe),
+    }
+    variants.update(_encode_alt(probe))
     return list(variants)
 
+
 def alternate_encodings(probe: str) -> list[str]:
-    return encode_alt(probe)
+    """Return encodings used when a probe appears to be blocked."""
+
+    return _encode_alt(probe)
+
+
+__all__ = [
+    "generate_variants",
+    "alternate_encodings",
+    "random_case",
+    "percent_encode_random",
+    "insert_special",
+]
+


### PR DESCRIPTION
## Summary
- add mutation helpers to randomize case, encoding and inject special characters
- fuzz coordinator now generates probe variants and retries with alternate encodings on 403/406 responses

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a8b92aaf1c83299421904b0d1ff139