### PR TITLE
Add regex signatures and confirmation logic

### DIFF
--- a/bounty_hunter/fuzz.py
+++ b/bounty_hunter/fuzz.py
@@ -145,6 +145,7 @@ class FuzzCoordinator:
             return None
 
         async def confirm() -> tuple[str, float]:
+            """Issue a second request to verify initial indicators."""
             try:
                 async with self.sem:
                     s = asyncio.get_event_loop().time()
@@ -153,45 +154,58 @@ class FuzzCoordinator:
             except Exception:
                 return "", 0.0
 
-        # XSS
+        # Collect indicator hits from the initial response.
+        xss_hit = False
+        sqli_err = False
+        sqli_delay = False
+        ssti_hit = False
+        ssrf_hit = False
+
         if category.startswith("XSS") or category == "LLM-variant":
-            if any(sig.search(text) for sig in XSS_PATTERNS):
-                ctext, _ = await confirm()
-                conf = 0.9 if any(sig.search(ctext) for sig in XSS_PATTERNS) else 0.4
-                await self._record(url, method, "Reflected XSS (indicator)", text, conf)
+            xss_hit = any(sig.search(text) for sig in XSS_PATTERNS)
 
-        # SQLi (error-based / time-based)
         if category.startswith("SQLi") or category == "LLM-variant":
-            hit = any(sig.search(text) for sig in SQLI_ERRORS)
-            delay = elapsed > self._rtt_threshold
-            if hit or delay:
-                ctext, celapsed = await confirm()
-                confirm_hit = any(sig.search(ctext) for sig in SQLI_ERRORS)
-                confirm_delay = celapsed > self._rtt_threshold
-                conf = 0.9 if (hit and confirm_hit) or (delay and confirm_delay) else 0.4
-                label = "Potential SQLi (error-based)" if hit else "Potential SQLi (time-based)"
-                await self._record(url, method, label, text, conf)
+            sqli_err = any(sig.search(text) for sig in SQLI_ERRORS)
+            sqli_delay = elapsed > self._rtt_threshold
 
-        # SSTI
         if category.startswith("SSTI") or category == "LLM-variant":
-            if any(sig.search(text) for sig in SSTI_PATTERNS):
-                ctext, _ = await confirm()
-                conf = 0.9 if any(sig.search(ctext) for sig in SSTI_PATTERNS) else 0.4
-                await self._record(url, method, "Template Injection indicator", text, conf)
+            ssti_hit = any(sig.search(text) for sig in SSTI_PATTERNS)
 
-        # SSRF (basic reflection heuristic)
         if category.startswith("SSRF") or category == "LLM-variant":
-            hit = ("169.254.169.254" in text) or ("127.0.0.1" in text) or ("localhost" in text)
-            if hit:
-                ctext, _ = await confirm()
-                confirm_hit = ("169.254.169.254" in ctext) or ("127.0.0.1" in ctext) or ("localhost" in ctext)
-                conf = 0.9 if confirm_hit else 0.4
-                await self._record(url, method, "SSRF indicator reflected", text, conf)
+            ssrf_hit = ("169.254.169.254" in text) or ("127.0.0.1" in text) or ("localhost" in text)
+
+        # Only perform a confirmation request when any indicator is present.
+        ctext = ""
+        celapsed = 0.0
+        if xss_hit or sqli_err or sqli_delay or ssti_hit or ssrf_hit:
+            ctext, celapsed = await confirm()
+
+        if xss_hit:
+            conf = 0.9 if any(sig.search(ctext) for sig in XSS_PATTERNS) else 0.4
+            await self._record(url, method, "Reflected XSS (indicator)", text, conf)
+
+        if sqli_err or sqli_delay:
+            confirm_hit = any(sig.search(ctext) for sig in SQLI_ERRORS)
+            confirm_delay = celapsed > self._rtt_threshold
+            conf = 0.9 if (sqli_err and confirm_hit) or (sqli_delay and confirm_delay) else 0.4
+            label = "Potential SQLi (error-based)" if sqli_err else "Potential SQLi (time-based)"
+            await self._record(url, method, label, text, conf)
+
+        if ssti_hit:
+            conf = 0.9 if any(sig.search(ctext) for sig in SSTI_PATTERNS) else 0.4
+            await self._record(url, method, "Template Injection indicator", text, conf)
+
+        if ssrf_hit:
+            confirm_hit = ("169.254.169.254" in ctext) or ("127.0.0.1" in ctext) or ("localhost" in ctext)
+            conf = 0.9 if confirm_hit else 0.4
+            await self._record(url, method, "SSRF indicator reflected", text, conf)
 
         return status
 
     async def _record(self, url: str, method: str, label: str, evidence_body: str, confidence: float) -> None:
+        msg = f"[{confidence:.2f}] {label} at {url}"
         if confidence >= self._confidence_threshold:
+            print(msg)
             curl = f"curl -i -X {method} '{url}'"
             f = Finding(
                 url=url,
@@ -204,4 +218,4 @@ class FuzzCoordinator:
             await self.reporter.write_finding(f, self.llm)
         else:
             # Low-confidence telemetry; keep noisy findings out of the formal report
-            print(f"[{confidence:.2f}] {label} at {url}")
+            print(msg)

--- a/bounty_hunter/signatures.py
+++ b/bounty_hunter/signatures.py
@@ -1,23 +1,41 @@
+"""Canonical signatures used by the fuzzing engine.
+
+Each category contains a list of compiled regular expressions so that new
+patterns can be appended over time as they are discovered.  Keeping the
+patterns centralised here allows other modules to share the same indicators and
+remain backward compatible across branches.
+"""
+
 import re
 
-# Multiple regex patterns for each category of indicator. These lists can be
-# extended over time as new signatures are discovered.
-XSS_PATTERNS=[
-    re.compile(r"BHXSS",re.I),
-    re.compile(r"<script[^>]*>BHXSS</script>",re.I),
+# --- XSS -------------------------------------------------------------------
+# The XSS list includes multiple representations of the sentinel value used by
+# the scanner when probing for reflected injection points.
+XSS_PATTERNS = [
+    re.compile(r"BHXSS", re.I),
+    re.compile(r"<script[^>]*>BHXSS</script>", re.I),
+    re.compile(r"onerror=BHXSS", re.I),
+    re.compile(r"\"BHXSS\"", re.I),
 ]
 
-SQLI_ERRORS=[
-    re.compile(r"SQL syntax",re.I),
-    re.compile(r"mysql_fetch|PDO|mysqli|ORA-\d+|PostgreSQL|SQLite",re.I),
-    re.compile(r"SQLSTATE\[HY000\]",re.I),
+# --- SQL Injection ---------------------------------------------------------
+# Common database error strings as well as generic SQL fragments that tend to
+# surface when an injection succeeds.
+SQLI_ERRORS = [
+    re.compile(r"SQL syntax", re.I),
+    re.compile(r"mysql_fetch|PDO|mysqli|ORA-\d+|PostgreSQL|SQLite", re.I),
+    re.compile(r"SQLSTATE\[HY000\]", re.I),
+    re.compile(r"UNION(?:\s+ALL)?\s+SELECT", re.I),
 ]
 
-SSTI_PATTERNS=[
-    re.compile(r"BHSTI",re.I),
-    re.compile(r"7\s*\*\s*7",re.I),
+# --- Server-Side Template Injection ---------------------------------------
+SSTI_PATTERNS = [
+    re.compile(r"BHSTI", re.I),
+    re.compile(r"7\s*\*\s*7", re.I),
+    re.compile(r"{{\s*7\s*\*\s*7\s*}}", re.I),
 ]
 
-# Responses taking longer than this threshold (in seconds) will be flagged as
-# potential time based vulnerabilities.
-RESPONSE_TIME_THRESHOLD=5
+# Responses taking longer than this threshold (in seconds) are flagged as
+# potential time-based vulnerabilities (e.g. time-based SQLi).
+RESPONSE_TIME_THRESHOLD = 5.0
+


### PR DESCRIPTION
## Summary
- broaden signature patterns for XSS, SQLi and SSTI and expose response time threshold
- perform confirmation requests once indicators are detected during fuzzing and log confidence levels
- report only findings above a configurable confidence threshold

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8b92b8ec08329b12af2617c8f33c4