### PR TITLE
Add host allowlist, jitter and request safety limits

### DIFF
--- a/bounty_hunter/config.py
+++ b/bounty_hunter/config.py
@@ -11,6 +11,7 @@ class Settings(BaseSettings):
     ALLOWED_HOSTS: list[str] = Field(default_factory=list, env="BH_ALLOWED_HOSTS")
     MAX_RESPONSE_SIZE: int = Field(default=1_000_000, env="BH_MAX_RESPONSE_SIZE")
     MAX_REDIRECT_DEPTH: int = Field(default=5, env="BH_MAX_REDIRECT_DEPTH")
+    JITTER_MAX_S: float = Field(default=0.5, env="BH_JITTER_MAX_S")
 
     # LLM
     LLM_PROVIDER: str = "none"  # none|openai

--- a/bounty_hunter/config.py
+++ b/bounty_hunter/config.py
@@ -8,6 +8,9 @@ class Settings(BaseSettings):
     RETRIES: int = Field(default=2, env="BH_RETRY")
     MAX_CONCURRENCY: int = Field(default=40, env="BH_MAX_CONCURRENCY")
     PER_HOST: int = Field(default=5, env="BH_PER_HOST")
+    ALLOWED_HOSTS: list[str] = Field(default_factory=list, env="BH_ALLOWED_HOSTS")
+    MAX_RESPONSE_SIZE: int = Field(default=1_000_000, env="BH_MAX_RESPONSE_SIZE")
+    MAX_REDIRECT_DEPTH: int = Field(default=5, env="BH_MAX_REDIRECT_DEPTH")
 
     # LLM
     LLM_PROVIDER: str = "none"  # none|openai

--- a/bounty_hunter/engine.py
+++ b/bounty_hunter/engine.py
@@ -50,7 +50,6 @@ async def run_scan(targets_path: Path, outdir: Path, program: str, settings: Set
         endpoints = sorted(set(harvest_res.endpoints))
 
         console.print(f"[green]\u2714[/] Harvested [bold]{len(endpoints)}[/] candidate endpoints")
-
         if settings.ALLOWED_HOSTS:
             before = len(endpoints)
             endpoints = [e for e in endpoints if URL(e).host and any(URL(e).host.endswith(h) for h in settings.ALLOWED_HOSTS)]

--- a/bounty_hunter/engine.py
+++ b/bounty_hunter/engine.py
@@ -30,7 +30,13 @@ async def run_scan(targets_path: Path, outdir: Path, program: str, settings: Set
     limits = httpx.Limits(max_connections=settings.MAX_CONCURRENCY, max_keepalive_connections=settings.MAX_CONCURRENCY)
     timeout = httpx.Timeout(settings.TIMEOUT_S)
     transport = httpx.HTTPTransport(retries=settings.RETRIES)
-    async with httpx.AsyncClient(http2=True, limits=limits, timeout=timeout, transport=transport, follow_redirects=False) as client:
+    async with httpx.AsyncClient(
+        http2=True,
+        limits=limits,
+        timeout=timeout,
+        transport=transport,
+        follow_redirects=False,
+    ) as client:
         rc = redis.from_url(settings.REDIS_URL, decode_responses=True)
 
         subs = await enumerate_subdomains(client, targets)


### PR DESCRIPTION
## Summary
- Support `ALLOWED_HOSTS`, `MAX_RESPONSE_SIZE`, and `MAX_REDIRECT_DEPTH` in settings
- Filter harvested endpoints against `ALLOWED_HOSTS` before scanning
- Introduce random jitter and request abort logic for oversized bodies or deep redirect chains

## Testing
- `python -m py_compile bounty_hunter/config.py bounty_hunter/engine.py bounty_hunter/fuzz.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8b92db4b483298ead876f21cbabce