### PR TITLE
feat: add attack chain support

### DIFF
--- a/bounty_hunter/cli.py
+++ b/bounty_hunter/cli.py
@@ -19,6 +19,7 @@ def scan(
     per_host: int = typer.Option(None),
     template: str = typer.Option("index"),
     oob: bool = typer.Option(False),
+    attack_chain: str = typer.Option(None, help="Name of attack chain in scripts/attack_flows"),
 ):
     s = Settings()
     if max_concurrency: s.MAX_CONCURRENCY = max_concurrency
@@ -28,3 +29,12 @@ def scan(
     console.print(f"Program: [bold]{program}[/] | LLM: [bold]{s.LLM_PROVIDER}[/] | OOB: [bold]{s.OOB_ENABLED}[/]")
     console.print(f"Concurrency: {s.MAX_CONCURRENCY} (per-host {s.PER_HOST})\n")
     asyncio.run(run_scan(targets, outdir, program, s, template=template))
+    if attack_chain:
+        from .lotl import run_attack_chain
+
+        console.rule(f"[bold red]Executing attack chain: {attack_chain}")
+        for res in run_attack_chain(attack_chain):
+            if res.stdout:
+                console.print(res.stdout)
+            if res.stderr:
+                console.print(res.stderr, style="red")

--- a/bounty_hunter/lotl.py
+++ b/bounty_hunter/lotl.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+from pathlib import Path
+import subprocess
+from typing import List
+
+
+def run_chain(commands: List[str]) -> List[subprocess.CompletedProcess[str]]:
+    """Execute a sequence of shell commands.
+
+    Each command is executed using the system shell allowing the
+    process to leverage existing tooling like ``curl`` or ``wget``.
+    The function collects ``CompletedProcess`` results for further
+    inspection by callers.
+    """
+    results: List[subprocess.CompletedProcess[str]] = []
+    for cmd in commands:
+        if not cmd.strip():
+            continue
+        results.append(
+            subprocess.run(cmd, shell=True, capture_output=True, text=True)
+        )
+    return results
+
+
+def run_attack_chain(name: str) -> List[subprocess.CompletedProcess[str]]:
+    """Run a predefined attack chain stored under ``scripts/attack_flows``.
+
+    Parameters
+    ----------
+    name:
+        Filename of the chain script relative to the ``scripts/attack_flows``
+        directory. Each non-empty, non-comment line in the file is executed
+        sequentially via :func:`run_chain`.
+    """
+    base = Path(__file__).resolve().parent.parent / "scripts" / "attack_flows"
+    script = base / name
+    if not script.exists():
+        raise FileNotFoundError(f"Attack chain '{name}' not found in {base}")
+    cmds = [
+        line.strip() for line in script.read_text().splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+    return run_chain(cmds)

--- a/scripts/attack_flows/sample.chain
+++ b/scripts/attack_flows/sample.chain
@@ -1,0 +1,7 @@
+# Example multi-stage attack chain using existing system tools.
+# Stage 1: Display curl version
+curl --version >/tmp/curl_version
+# Stage 2: Display wget version
+wget --version >/tmp/wget_version
+# Stage 3: Output collected information
+cat /tmp/curl_version /tmp/wget_version


### PR DESCRIPTION
## Summary
- add lotl module for running chained system commands
- support executing attack chains via `scan` CLI option
- provide sample multi-stage attack script leveraging curl and wget

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8b93ef24483298884237d8d42403f