### PR TITLE
feat: add adaptive rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 python -m bounty_hunter scan --targets scope.txt --program "Acme BBP" --template h1
 ```
+
+## Environment
+
+Set `BH_ADAPTIVE_RATE=true` to enable adaptive throttling when many requests error.

--- a/bounty_hunter/config.py
+++ b/bounty_hunter/config.py
@@ -8,6 +8,7 @@ class Settings(BaseSettings):
     RETRIES: int = Field(default=2, env="BH_RETRY")
     MAX_CONCURRENCY: int = Field(default=40, env="BH_MAX_CONCURRENCY")
     PER_HOST: int = Field(default=5, env="BH_PER_HOST")
+    ADAPTIVE_RATE: bool = Field(default=False, env="BH_ADAPTIVE_RATE")
 
     # LLM
     LLM_PROVIDER: str = "none"  # none|openai


### PR DESCRIPTION
## Summary
- track request failures in fuzzing and reduce concurrency on high error rates
- add optional `BH_ADAPTIVE_RATE` setting
- document adaptive rate environment variable

## Testing
- `python -m py_compile bounty_hunter/fuzz.py bounty_hunter/config.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68a8b93c91a88329b262b8a2427742cb