### PR TITLE
Add persistence helpers for optional writable checks

### DIFF
--- a/bounty_hunter/persistence.py
+++ b/bounty_hunter/persistence.py
@@ -1,0 +1,87 @@
+"""Utilities for optional persistence checks.
+
+This module exposes helper functions that allow other parts of the
+project to non-destructively check whether configuration files or
+directories are writable and to store a minimal nonce file for verifying
+persistence across runs.
+
+All helpers are safe by default: they do not modify existing files
+unless explicitly asked to create a nonce file.  The nonce helpers write
+very small files containing a random token that can be removed after the
+check has completed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Tuple
+import os
+import uuid
+
+
+def is_writable(path: str | Path) -> bool:
+    """Return True if ``path`` is writable without modifying it.
+
+    The check is non-destructive and will fall back to the parent
+    directory when ``path`` does not yet exist.
+    """
+    p = Path(path)
+    target = p if p.exists() else p.parent
+    try:
+        return os.access(target, os.W_OK)
+    except OSError:
+        return False
+
+
+def check_writable(paths: Iterable[str | Path]) -> dict[str, bool]:
+    """Check a collection of paths for writability.
+
+    Parameters
+    ----------
+    paths:
+        Paths to examine.  Each entry may point to a file or directory.
+
+    Returns
+    -------
+    Mapping of the original path (string representation) to a boolean
+    indicating writability.
+    """
+    return {str(p): is_writable(p) for p in paths}
+
+
+def write_nonce(directory: str | Path, name: str = "bh.nonce", nonce: str | None = None) -> Tuple[Path, str]:
+    """Write a minimal nonce file into ``directory``.
+
+    ``directory`` will be created if it does not already exist.  A newly
+    generated UUID4 string is used when ``nonce`` is not supplied.
+
+    Returns the path to the nonce file along with the value written.
+    """
+    d = Path(directory)
+    d.mkdir(parents=True, exist_ok=True)
+    if nonce is None:
+        nonce = uuid.uuid4().hex
+    nonce_path = d / name
+    nonce_path.write_text(nonce)
+    return nonce_path, nonce
+
+
+def read_nonce(path: str | Path) -> str | None:
+    """Read a nonce file and return its contents or ``None`` if missing."""
+    try:
+        return Path(path).read_text().strip()
+    except OSError:
+        return None
+
+
+def verify_nonce(path: str | Path, expected: str) -> bool:
+    """Verify that ``path`` contains ``expected`` nonce value."""
+    return read_nonce(path) == expected
+
+__all__ = [
+    "is_writable",
+    "check_writable",
+    "write_nonce",
+    "read_nonce",
+    "verify_nonce",
+]

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -1,0 +1,42 @@
+# Persistence Helpers
+
+The `bounty_hunter.persistence` module provides optional utilities for
+safely checking whether the application can write to disk and for
+storing minimal data used to verify persistence between runs.
+
+## Writable checks
+
+Use `is_writable` or `check_writable` to determine if a file or
+ directory is writable without modifying it:
+
+```python
+from bounty_hunter.persistence import is_writable
+
+if is_writable("config.yaml"):
+    print("config can be updated")
+```
+
+The check is non-destructive and falls back to the parent directory when
+the file does not yet exist.
+
+## Nonce files
+
+Modules that need to confirm persistence can write a nonce file and
+later verify its value:
+
+```python
+from bounty_hunter.persistence import write_nonce, verify_nonce
+
+path, value = write_nonce("/tmp/bh")
+# ... later ...
+assert verify_nonce(path, value)
+```
+
+Nonce files contain only a random token and can be removed once they are
+no longer needed.
+
+## Safe usage
+
+These helpers are optional; they will never modify existing files unless
+you explicitly call `write_nonce`.  The small nonce files are created
+in user-specified directories and are safe to delete.


### PR DESCRIPTION
## Summary
- add `persistence` module with non-destructive writable checks and nonce helpers
- document persistence utilities and safe usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8b93b4f088329bc811508bd625f0b