### PR TITLE
Add chain analysis to report index

### DIFF
--- a/bounty_hunter/chain_analyzer.py
+++ b/bounty_hunter/chain_analyzer.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Dict, Set, List
+
+
+class ChainAnalyzer:
+    """Suggest exploit chains based on finding relationships."""
+
+    def __init__(self, graph: Dict[str, Set[str]], items: List[Dict[str, str]]):
+        self.graph = graph
+        self.items = items
+        self.categories = {i["name"]: i.get("category", "").lower() for i in items}
+
+    def suggest(self) -> List[str]:
+        """Return simple chain recommendations."""
+        suggestions: Set[str] = set()
+        for src, targets in self.graph.items():
+            src_cat = self.categories.get(src, "")
+            for dst in targets:
+                dst_cat = self.categories.get(dst, "")
+                if self._is_redirect_ssrf(src_cat, dst_cat):
+                    suggestions.add(f"{src} → {dst} (redirect → SSRF)")
+                elif self._is_redirect_ssrf(dst_cat, src_cat):
+                    suggestions.add(f"{dst} → {src} (redirect → SSRF)")
+        return sorted(suggestions)
+
+    @staticmethod
+    def _is_redirect_ssrf(a: str, b: str) -> bool:
+        return "redirect" in a and "ssrf" in b


### PR DESCRIPTION
## Summary
- track relationships between findings by shared endpoints/params
- suggest redirect→SSRF chains and include them in INDEX.md

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8b9372d9083298b2c7c306f8f5828