### PR TITLE
Add proxy support and improve opsec guidance

### DIFF
--- a/bounty_hunter/config.py
+++ b/bounty_hunter/config.py
@@ -8,6 +8,7 @@ class Settings(BaseSettings):
     RETRIES: int = Field(default=2, env="BH_RETRY")
     MAX_CONCURRENCY: int = Field(default=40, env="BH_MAX_CONCURRENCY")
     PER_HOST: int = Field(default=5, env="BH_PER_HOST")
+    PROXY_URL: str | None = Field(default=None, env="BH_PROXY_URL")
 
     # LLM
     LLM_PROVIDER: str = "none"  # none|openai

--- a/bounty_hunter/engine.py
+++ b/bounty_hunter/engine.py
@@ -29,7 +29,15 @@ async def run_scan(targets_path: Path, outdir: Path, program: str, settings: Set
     limits = httpx.Limits(max_connections=settings.MAX_CONCURRENCY, max_keepalive_connections=settings.MAX_CONCURRENCY)
     timeout = httpx.Timeout(settings.TIMEOUT_S)
     transport = httpx.HTTPTransport(retries=settings.RETRIES)
-    async with httpx.AsyncClient(http2=True, limits=limits, timeout=timeout, transport=transport, follow_redirects=False) as client:
+    proxies = settings.PROXY_URL or None
+    async with httpx.AsyncClient(
+        http2=True,
+        limits=limits,
+        timeout=timeout,
+        transport=transport,
+        follow_redirects=False,
+        proxies=proxies,
+    ) as client:
         rc = redis.from_url(settings.REDIS_URL, decode_responses=True)
 
         subs = await enumerate_subdomains(client, targets)

--- a/bounty_hunter/report.py
+++ b/bounty_hunter/report.py
@@ -109,7 +109,7 @@ class ReportWriter:
         score, severity = calculate_cvss(vector) if vector else (0.0, "")
 
         # Optional fields
-        headers = getattr(f, "headers", "") or ""
+        headers = self._scrub_headers(getattr(f, "headers", "") or "")
         body = getattr(f, "body", "") or ""
         confidence = float(getattr(f, "confidence", 0.0))
 
@@ -163,13 +163,14 @@ class ReportWriter:
             else ""
         )
 
+        scrubbed_headers = self._scrub_headers(headers)
         md = (
             f"# {category}\n\n"
             f"**Program:** {self.program}\n"
             f"**Endpoint:** `{endpoint}`\n"
             f"{cvss_block}"
             f"## Proof of Concept\n```bash\n{curl}\n```\n"
-            f"{f'## Request Headers\n```http\n{headers}\n```\n' if headers else ''}"
+            f"{f'## Request Headers\n```http\n{scrubbed_headers}\n```\n' if scrubbed_headers else ''}"
             f"{f'## Request Body\n```http\n{body}\n```\n' if body else ''}"
             f"## Evidence (Truncated)\n```text\n{evidence}\n```\n"
             f"{(artifact + '\n') if artifact else ''}"
@@ -193,7 +194,7 @@ class ReportWriter:
                     "category": first,
                     "endpoint": self._extract_field(txt, "Endpoint:"),
                     "curl": self._extract_block(txt, "Proof of Concept"),
-                    "headers": self._extract_block(txt, "Request Headers"),
+                    "headers": self._scrub_headers(self._extract_block(txt, "Request Headers")),
                     "body": self._extract_block(txt, "Request Body"),
                     "evidence": self._extract_block(txt, "Evidence"),
                     "impact": self._extract_section(txt, "Impact"),
@@ -239,6 +240,28 @@ class ReportWriter:
     def _extract_section(txt: str, header: str) -> str:
         i = txt.lower().find(header.lower())
         return "" if i == -1 else txt[i : i + 400]
+
+    @staticmethod
+    def _scrub_headers(headers: str) -> str:
+        """
+        Redact sensitive header values before they are written to disk.
+        """
+        sensitive = {
+            "authorization",
+            "proxy-authorization",
+            "cookie",
+            "set-cookie",
+            "x-api-key",
+            "x-api-token",
+        }
+        cleaned = []
+        for line in headers.splitlines():
+            name, sep, value = line.partition(":")
+            if sep and name.strip().lower() in sensitive:
+                cleaned.append(f"{name}{sep} [REDACTED]")
+            else:
+                cleaned.append(line)
+        return "\n".join(cleaned)
 
     @staticmethod
     def _artifact_snippet(slug: str) -> str:

--- a/docs/OPSEC.md
+++ b/docs/OPSEC.md
@@ -1,0 +1,30 @@
+# Operational Security
+
+When scanning targets, route traffic through anonymity networks or VPNs to
+avoid exposing your home IP.
+
+## Tor
+
+1. Install and start Tor locally.
+2. Expose the SOCKS proxy (default `127.0.0.1:9050`).
+3. Export the proxy URL before running scans:
+
+```bash
+export BH_PROXY_URL="socks5://127.0.0.1:9050"
+```
+
+All HTTP requests will be sent through the Tor network.
+
+## VPN
+
+When using a commercial VPN or corporate tunnel, set the proxy to the VPN
+endpoint if one is provided:
+
+```bash
+export BH_PROXY_URL="http://vpn-proxy.local:8080"
+```
+
+Alternatively, run the scanner inside the VPN-protected environment.
+
+Always verify that your traffic is correctly routed before interacting with
+third-party systems.


### PR DESCRIPTION
## Summary
- allow routing requests through a configured proxy via new `PROXY_URL` setting
- redact sensitive headers before writing findings
- document how to route traffic through Tor or a VPN

## Testing
- `python -m py_compile bounty_hunter/config.py bounty_hunter/engine.py bounty_hunter/report.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8b936251c8329a397712b13de2194