### PR TITLE
feat: pace requests with random user agents

### DIFF
--- a/bounty_hunter/config.py
+++ b/bounty_hunter/config.py
@@ -8,6 +8,8 @@ class Settings(BaseSettings):
     RETRIES: int = Field(default=2, env="BH_RETRY")
     MAX_CONCURRENCY: int = Field(default=40, env="BH_MAX_CONCURRENCY")
     PER_HOST: int = Field(default=5, env="BH_PER_HOST")
+    RANDOM_UA: bool = Field(default=True, env="BH_RANDOM_UA")
+    REQUEST_JITTER_MS: int = Field(default=250, env="BH_REQUEST_JITTER_MS")
 
     # LLM
     LLM_PROVIDER: str = "none"  # none|openai

--- a/bounty_hunter/engine.py
+++ b/bounty_hunter/engine.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn
 from .config import Settings
+from .http_client import BHClient
 from .harvest import harvest_from_targets
 from .workflow import WorkflowAnalyzer
 from .fuzz import FuzzCoordinator
@@ -29,7 +30,7 @@ async def run_scan(targets_path: Path, outdir: Path, program: str, settings: Set
     limits = httpx.Limits(max_connections=settings.MAX_CONCURRENCY, max_keepalive_connections=settings.MAX_CONCURRENCY)
     timeout = httpx.Timeout(settings.TIMEOUT_S)
     transport = httpx.HTTPTransport(retries=settings.RETRIES)
-    async with httpx.AsyncClient(http2=True, limits=limits, timeout=timeout, transport=transport, follow_redirects=False) as client:
+    async with BHClient(settings=settings, http2=True, limits=limits, timeout=timeout, transport=transport, follow_redirects=False) as client:
         rc = redis.from_url(settings.REDIS_URL, decode_responses=True)
 
         subs = await enumerate_subdomains(client, targets)

--- a/bounty_hunter/http_client.py
+++ b/bounty_hunter/http_client.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+import asyncio, random
+from collections import defaultdict
+import httpx
+from yarl import URL
+from typing import Dict
+
+# A small pool of common user-agent strings
+USER_AGENTS = [
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0 Safari/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0 Safari/537.36",
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+]
+
+class BHClient(httpx.AsyncClient):
+    """Async HTTP client with per-domain pacing and random user agents."""
+
+    def __init__(self, *, settings, **kwargs):
+        super().__init__(**kwargs)
+        self.settings = settings
+        self._locks: Dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
+
+    async def request(self, method: str, url: str, headers: dict | None = None, **kwargs):  # type: ignore[override]
+        headers = headers.copy() if headers else {}
+        if self.settings.RANDOM_UA:
+            headers.setdefault("User-Agent", random.choice(USER_AGENTS))
+        host = URL(url).host or ""
+        lock = self._locks[host]
+        async with lock:
+            jitter = random.uniform(0, self.settings.REQUEST_JITTER_MS) / 1000
+            if jitter > 0:
+                await asyncio.sleep(jitter)
+            return await super().request(method, url, headers=headers, **kwargs)


### PR DESCRIPTION
## Summary
- add configurable random user-agent and request jitter settings
- introduce BHClient wrapper with per-domain pacing and jittered requests
- use paced client across scanning engine

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8b9334d748329a3910b448505622d