### PR TITLE
Add resumable scans with module configuration

### DIFF
--- a/bounty_hunter/cli.py
+++ b/bounty_hunter/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import asyncio
 from pathlib import Path
+import json
 import typer
 from rich.console import Console
 from .config import Settings
@@ -19,12 +20,21 @@ def scan(
     per_host: int = typer.Option(None),
     template: str = typer.Option("index"),
     oob: bool = typer.Option(False),
+    resume: bool = typer.Option(False, help="Resume from saved state"),
+    modules: str = typer.Option("modules.json", help="Module configuration file"),
 ):
     s = Settings()
-    if max_concurrency: s.MAX_CONCURRENCY = max_concurrency
-    if per_host: s.PER_HOST = per_host
-    s.LLM_PROVIDER = llm.lower(); s.OOB_ENABLED = oob
+    if max_concurrency:
+        s.MAX_CONCURRENCY = max_concurrency
+    if per_host:
+        s.PER_HOST = per_host
+    module_flags = {}
+    modules_path = Path(modules)
+    if modules_path.exists():
+        module_flags = json.loads(modules_path.read_text())
+    s.LLM_PROVIDER = llm.lower()
+    s.OOB_ENABLED = oob or module_flags.get("oob", False)
     console.rule("[bold cyan]AI Bug Bounty Hunter")
     console.print(f"Program: [bold]{program}[/] | LLM: [bold]{s.LLM_PROVIDER}[/] | OOB: [bold]{s.OOB_ENABLED}[/]")
     console.print(f"Concurrency: {s.MAX_CONCURRENCY} (per-host {s.PER_HOST})\n")
-    asyncio.run(run_scan(targets, outdir, program, s, template=template))
+    asyncio.run(run_scan(targets, outdir, program, s, template=template, resume=resume, modules=module_flags))

--- a/bounty_hunter/engine.py
+++ b/bounty_hunter/engine.py
@@ -21,68 +21,117 @@ from .subdomains import enumerate_subdomains
 
 console = Console()
 
-async def run_scan(targets_path: Path, outdir: Path, program: str, settings: Settings, template: str = "index"):
+async def run_scan(
+    targets_path: Path,
+    outdir: Path,
+    program: str,
+    settings: Settings,
+    template: str = "index",
+    resume: bool = False,
+    modules: dict[str, bool] | None = None,
+):
+    modules = modules or {}
+    state_file = outdir / "state.json"
+
     targets = [t.strip() for t in targets_path.read_text().splitlines() if t.strip() and not t.strip().startswith('#')]
     if not targets:
         console.print("[bold red]No targets provided."); return
-    outdir = outdir / f"{int(anyio.current_time())}"; outdir.mkdir(parents=True, exist_ok=True)
+
+    if not resume:
+        outdir = outdir / f"{int(anyio.current_time())}"
+        outdir.mkdir(parents=True, exist_ok=True)
+    else:
+        if not outdir.exists() or not state_file.exists():
+            console.print("[bold red]State file not found for resume.")
+            return
+
     limits = httpx.Limits(max_connections=settings.MAX_CONCURRENCY, max_keepalive_connections=settings.MAX_CONCURRENCY)
     timeout = httpx.Timeout(settings.TIMEOUT_S)
     transport = httpx.HTTPTransport(retries=settings.RETRIES)
     async with httpx.AsyncClient(http2=True, limits=limits, timeout=timeout, transport=transport, follow_redirects=False) as client:
         rc = redis.from_url(settings.REDIS_URL, decode_responses=True)
 
-        subs = await enumerate_subdomains(client, targets)
-        if subs:
-            console.print(f"[cyan]＋[/] Subdomain enumerator discovered [bold]{len(subs)}[/] hosts")
-            targets.extend(subs)
-        llm = LLM.from_settings(settings)
-        with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}")) as p:
-            p.add_task(description="Harvesting endpoints…", total=None)
-            harvest_res = await harvest_from_targets(client, targets, settings)
-        endpoints = sorted(set(harvest_res.endpoints))
+        if resume:
+            state = json.loads(state_file.read_text())
+            endpoints = state.get("endpoints", [])
+            progress = state.get("progress", 0)
+            llm = LLM.from_settings(settings)
+            reporter = ReportWriter(base=outdir, program=program, template=template)
+        else:
+            subs = []
+            if modules.get("subdomains", True):
+                subs = await enumerate_subdomains(client, targets)
+                if subs:
+                    console.print(f"[cyan]＋[/] Subdomain enumerator discovered [bold]{len(subs)}[/] hosts")
+                    targets.extend(subs)
+            llm = LLM.from_settings(settings)
+            with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}")) as p:
+                p.add_task(description="Harvesting endpoints…", total=None)
+                harvest_res = await harvest_from_targets(client, targets, settings)
+            endpoints = sorted(set(harvest_res.endpoints))
 
-        console.print(f"[green]\u2714[/] Harvested [bold]{len(endpoints)}[/] candidate endpoints")
+            console.print(f"[green]\u2714[/] Harvested [bold]{len(endpoints)}[/] candidate endpoints")
 
-        analyzer = WorkflowAnalyzer(harvest_res.forms, harvest_res.navigations, llm)
-        for wf, issues, llm_notes in await analyzer.analyze():
-            if issues or llm_notes:
-                console.print("[yellow]Workflow issues detected:[/]")
-                for issue in issues:
-                    console.print(f" - {issue}")
-                if llm_notes:
-                    console.print(f" [LLM] {llm_notes}")
-        reporter = ReportWriter(base=outdir, program=program, template=template)
-        mined = await JSMiner(client, settings).mine(endpoints)
-        if mined:
-            console.print(f"[cyan]＋[/] JS miner discovered [bold]{len(mined)}[/] extra candidates"); endpoints.extend(mined)
-        endpoints = sorted(set(endpoints))
+            if modules.get("workflow", True):
+                analyzer = WorkflowAnalyzer(harvest_res.forms, harvest_res.navigations, llm)
+                for wf, issues, llm_notes in await analyzer.analyze():
+                    if issues or llm_notes:
+                        console.print("[yellow]Workflow issues detected:[/]")
+                        for issue in issues:
+                            console.print(f" - {issue}")
+                        if llm_notes:
+                            console.print(f" [LLM] {llm_notes}")
+            reporter = ReportWriter(base=outdir, program=program, template=template)
+            mined = []
+            if modules.get("jsminer", True):
+                mined = await JSMiner(client, settings).mine(endpoints)
+            if mined:
+                console.print(f"[cyan]＋[/] JS miner discovered [bold]{len(mined)}[/] extra candidates"); endpoints.extend(mined)
+            endpoints = sorted(set(endpoints))
+            state = {"endpoints": endpoints, "progress": 0}
+            state_file.write_text(json.dumps(state, indent=2))
+            progress = 0
+
         await rc.delete(settings.REDIS_QUEUE)
-        for i in range(0, len(endpoints), settings.CHUNK_SIZE):
+        for i in range(progress, len(endpoints), settings.CHUNK_SIZE):
             chunk = endpoints[i:i + settings.CHUNK_SIZE]
             await rc.rpush(settings.REDIS_QUEUE, json.dumps(chunk))
 
+        progress_lock = anyio.Lock()
+
         async def worker():
+            nonlocal progress
             while True:
                 item = await rc.blpop(settings.REDIS_QUEUE, timeout=1)
                 if not item:
                     break
                 _, payload = item
                 chunk = json.loads(payload)
-                await FuzzCoordinator(client=client, llm=llm, reporter=reporter, settings=settings).run(chunk)
-                await RedirectChecker(client, reporter, settings).run(chunk)
-                await AuthChecker(client, reporter, settings).run(chunk)
-                await SignedURLChecker(client, reporter, settings).run(chunk)
-                await JWTChecker(client, reporter, settings).run(chunk)
-                for fp in await Fingerprinter(client, settings).run(chunk):
-                    await reporter.generic_finding(
-                        category=f"Fingerprint: {fp.product}",
-                        endpoint=fp.endpoint,
-                        evidence=f"mmh3={fp.hash} headers={dict(list(fp.headers.items())[:10])}\\n{fp.notes}",
-                        curl=f"curl -i '{fp.endpoint}'",
-                    )
-                if settings.OOB_ENABLED:
+                if modules.get("fuzz", True):
+                    await FuzzCoordinator(client=client, llm=llm, reporter=reporter, settings=settings).run(chunk)
+                if modules.get("redirects", True):
+                    await RedirectChecker(client, reporter, settings).run(chunk)
+                if modules.get("auth", True):
+                    await AuthChecker(client, reporter, settings).run(chunk)
+                if modules.get("signedurls", True):
+                    await SignedURLChecker(client, reporter, settings).run(chunk)
+                if modules.get("jwt", True):
+                    await JWTChecker(client, reporter, settings).run(chunk)
+                if modules.get("fingerprint", True):
+                    for fp in await Fingerprinter(client, settings).run(chunk):
+                        await reporter.generic_finding(
+                            category=f"Fingerprint: {fp.product}",
+                            endpoint=fp.endpoint,
+                            evidence=f"mmh3={fp.hash} headers={dict(list(fp.headers.items())[:10])}\n{fp.notes}",
+                            curl=f"curl -i '{fp.endpoint}'",
+                        )
+                if modules.get("oob", settings.OOB_ENABLED):
                     await OOBSSRF(client, reporter, settings).run(chunk)
+
+                async with progress_lock:
+                    progress += len(chunk)
+                    state["progress"] = progress
+                    state_file.write_text(json.dumps(state, indent=2))
 
         async with anyio.create_task_group() as tg:
             for _ in range(settings.WORKERS):

--- a/modules.json
+++ b/modules.json
@@ -1,0 +1,12 @@
+{
+  "subdomains": true,
+  "workflow": true,
+  "jsminer": true,
+  "fuzz": true,
+  "redirects": true,
+  "auth": true,
+  "signedurls": true,
+  "jwt": true,
+  "fingerprint": true,
+  "oob": false
+}


### PR DESCRIPTION
## Summary
- persist harvested endpoints and progress to `state.json` for resumable scans
- add `--resume` flag and module config loading in CLI
- introduce JSON config to enable or disable individual modules

## Testing
- `python -m pytest`
- `python -m bounty_hunter --help` *(fails: Parameter.make_metavar() missing 1 required positional argument: 'ctx')*


------
https://chatgpt.com/codex/tasks/task_e_68a8b92f0b0c8329a88c009955fbe331